### PR TITLE
fix: remediate HashiCorp Vault connector vulnerabilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/NOTICE
+++ b/NOTICE
@@ -210,4 +210,3 @@ License Text:
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/hashicorp_vault.json
+++ b/hashicorp_vault.json
@@ -25,7 +25,7 @@
         "verify_server_cert": {
             "description": "Verify server certificate",
             "data_type": "boolean",
-            "default": false,
+            "default": true,
             "order": 0
         },
         "vault_url": {

--- a/hashicorp_vault.json
+++ b/hashicorp_vault.json
@@ -11,7 +11,7 @@
     "product_vendor": "Dallan",
     "product_name": "Hashicorp Vault",
     "product_version_regex": ".*",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "min_phantom_version": "7.0.0",
     "logo": "logo_hashicorp_vault.svg",
     "logo_dark": "logo_hashicorp_vault_dark.svg",

--- a/hashicorp_vault_connector.py
+++ b/hashicorp_vault_connector.py
@@ -89,6 +89,13 @@ class AppConnectorHashicorpVault(phantom.BaseConnector):
         mountpoint = config["vault_mountpoint"]
         return mountpoint
 
+    def _get_validated_location(self, param, action_result):
+        path = param.get("location")
+        if not isinstance(path, str) or ".." in path.split("/"):
+            return RetVal(action_result.set_status(phantom.APP_ERROR, HASHICORP_VAULT_UNSAFE_LOCATION_ERR), None)
+
+        return RetVal(phantom.APP_SUCCESS, path)
+
     def _create_vault_client(self, action_result):
         config = self.get_config()
 
@@ -146,12 +153,15 @@ class AppConnectorHashicorpVault(phantom.BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, "Failed to create Hashicorp Vault client")
 
     def _set_secret(self, param, action_result):
+        ret_val, path = self._get_validated_location(param, action_result)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+
         ret_val, hvac_client = self._create_vault_client(action_result)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
         mountpoint = self._get_mountpoint()
-        path = param.get("location")
         secret = param.get("secret_json")
         try:
             secret = json.loads(secret)
@@ -175,11 +185,14 @@ class AppConnectorHashicorpVault(phantom.BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, f"Please verify 'secret_json' action parameter. {err}")
 
     def _get_secret(self, param, action_result):
+        ret_val, path = self._get_validated_location(param, action_result)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+
         ret_val, hvac_client = self._create_vault_client(action_result)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
         mountpoint = self._get_mountpoint()
-        path = param.get("location")
         try:
             read_response = hvac_client.secrets.kv.v2.read_secret_version(mount_point=mountpoint, path=path)
             if read_response:
@@ -206,11 +219,14 @@ class AppConnectorHashicorpVault(phantom.BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, f"Error in retrieving secret value from Hashicorp Vault. {err}")
 
     def _list_secrets(self, param, action_result):
+        ret_val, path = self._get_validated_location(param, action_result)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+
         ret_val, hvac_client = self._create_vault_client(action_result)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
         mountpoint = self._get_mountpoint()
-        path = param.get("location")
         try:
             list_secrets = hvac_client.secrets.kv.v2.list_secrets(mount_point=mountpoint, path=path)
             if list_secrets:

--- a/hashicorp_vault_consts.py
+++ b/hashicorp_vault_consts.py
@@ -33,3 +33,4 @@ HASHICORP_VAULT_NO_AUTH_CREDENTIALS_ERR = (
     "Please provide either AppRole credentials (Role ID + Secret ID) or a Vault token in the asset configuration."
 )
 HASHICORP_VAULT_INCOMPLETE_APPROLE_ERR = "Incomplete AppRole credentials: both 'vault_role_id' and 'vault_secret_id' must be provided together."
+HASHICORP_VAULT_UNSAFE_LOCATION_ERR = "The location must not contain parent-directory ('..') path segments."

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Updated connector development tooling and supported Python versions.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * - Updated connector development tooling and supported Python versions.
+* Enabled TLS certificate verification by default for new assets. Existing assets retain their saved setting and should be reviewed after upgrade.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,5 +1,5 @@
 **Unreleased**
 
-* - Updated connector development tooling and supported Python versions.
+* Updated connector development tooling and supported Python versions.
 * Enabled TLS certificate verification by default for new assets. Existing assets retain their saved setting and should be reviewed after upgrade.
 * Rejected Vault secret locations containing parent-directory path segments to keep requests inside the configured mount.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * - Updated connector development tooling and supported Python versions.
 * Enabled TLS certificate verification by default for new assets. Existing assets retain their saved setting and should be reviewed after upgrade.
+* Rejected Vault secret locations containing parent-directory path segments to keep requests inside the configured mount.


### PR DESCRIPTION
## Summary

- enable TLS certificate verification by default for newly created assets
- reject parent-directory path segments before Vault credentials are used
- refresh the connector tooling baseline to dev-cicd-tools v2.2.4

## Tracking

- PAPP-38199
- PSAAS-30916
- PSAAS-31434
- Parent epic: ESPM-5228

## Validation

- local pre-commit: passed
- hosted pre-commit and compile: pending

## AI assistance

- [x] This pull request was created entirely with AI assistance.

Written by Codex.